### PR TITLE
Replace default for decimal parameter of read functions.

### DIFF
--- a/R/read-tsExport.R
+++ b/R/read-tsExport.R
@@ -116,7 +116,7 @@
 #   list2env(envir = .GlobalEnv)
 # TODO: ...redo until here?
 read_tsExport_table <- function(data_dir, file_name, 
-                                separator = ";", decimal = ".",
+                                separator = ";", decimal = ",",
                                 encoding = "UTF-8",
                                 quote_escape_detect = FALSE,
                                 escape_backslash = TRUE){
@@ -203,7 +203,7 @@ read_tsExport_table <- function(data_dir, file_name,
 #' @importFrom rlang .data
 #' @export 
 read_tsExport_raw <- function(data_dir,
-                              separator = ";", decimal = ".",
+                              separator = ";", decimal = ",",
                               encoding = "UTF-8",
                               quote_escape_detect = TRUE,
                               escape_backslash = TRUE) {
@@ -958,7 +958,7 @@ dates_tsExport <- function(tsExport) {
 #' @return \code{tsExportdata} object - a list with one data.frame for each file 
 #'   on the export and a list containing the export options
 #' @export
-read_tsExport <- function(data_dir, separator = ";", decimal = ".",
+read_tsExport <- function(data_dir, separator = ";", decimal = ",",
                           encoding = "UTF-8",
                           quote_escape_detect = TRUE,
                           escape_backslash = TRUE,

--- a/man/read_tsExport.Rd
+++ b/man/read_tsExport.Rd
@@ -7,7 +7,7 @@
 read_tsExport(
   data_dir,
   separator = ";",
-  decimal = ".",
+  decimal = ",",
   encoding = "UTF-8",
   quote_escape_detect = TRUE,
   escape_backslash = TRUE,

--- a/man/read_tsExport_raw.Rd
+++ b/man/read_tsExport_raw.Rd
@@ -7,7 +7,7 @@
 read_tsExport_raw(
   data_dir,
   separator = ";",
-  decimal = ".",
+  decimal = ",",
   encoding = "UTF-8",
   quote_escape_detect = TRUE,
   escape_backslash = TRUE


### PR DESCRIPTION
See Issue #2
	modified:   R/read-tsExport.R

# Pull Request

## Description

In read-tsExport.R the default value decimal parameter for the data reading functions are switched from "." to ",". 

- Fixes # 2


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Not tested

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new code warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules/packages
