### PR TITLE
Bugfix/issue17

### DIFF
--- a/R/write-tsExport.R
+++ b/R/write-tsExport.R
@@ -44,11 +44,21 @@ write_tsExport.tsExportdata <- function(object, format = "dta", metadata = FALSE
   if (! format %in% c("dta", "sas", "sav", "xpt")) {
     stop(paste0("format must be one of 'dta', 'sas', 'sav', 'xpt'. You specified: ", format))
   }
-  x <- object$export_options$data_names
-  names(x) <- NULL
-  if (!metadata) x <- x[!x %in% object$export_options$meta_names]
   
-  lapply(x, function(obs) {
+  df_names <- object %>% 
+    purrr::keep(~ is.data.frame(.x)) %>% 
+    names()
+  
+  # Export only named data sets from the object. Print a warning if unnamed
+  # data sets where found.
+  if ("" %in% df_names) {
+    warning("Unnamed data sets where found in the data object. Can only export named data sets.")
+    df_names <- setdiff(df_names, "")
+  }
+  
+  if (!metadata) df_names <- df_names[!df_names %in% object$export_options$meta_names]
+  
+  lapply(df_names, function(obs) {
     tmp <- object[[obs]]
     write_tsExport(tmp, filename = obs, format = format, ...)
   })

--- a/R/write-tsExport.R
+++ b/R/write-tsExport.R
@@ -49,10 +49,10 @@ write_tsExport.tsExportdata <- function(object, format = "dta", metadata = FALSE
     purrr::keep(~ is.data.frame(.x)) %>% 
     names()
   
-  # Export only named data sets from the object. Print a warning if unnamed
+  # Export only named data frames from the object. Print a warning if unnamed
   # data sets where found.
   if ("" %in% df_names) {
-    warning("Unnamed data sets where found in the data object. Can only export named data sets.")
+    warning("Unnamed data frames where found in the data object. Can only export named data sets.")
     df_names <- setdiff(df_names, "")
   }
   


### PR DESCRIPTION
# Pull Request

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

- Fixes #17 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

The `write_tsExport()` function used to get the names of the data frames that will be exported from `data$export_options$data_names` which contains only the data file names of the original transfer office export. Now the functions get the names of the data frames directly from the `names()` function applied to the data object. Unnamed data frames won't be exported. Instead a warning message will be printed.

## How Has This Been Tested?

Tested with primary coded suep data, exported to *.sav files. The file `ecu_who_scale_per_visit_data.sav` was now created.

```r
data_suep <- read_tsExport(data_dir)

data_primary_coded_suep <- data_suep %>% 
    primary_coding_suep()

data_spss_export_prepared_suep <- prepare_spss_export(data_primary_coded_suep, 
                                                 rm_stdates = TRUE,
                                                 set_missings = TRUE)

write_tsExport(data_spss_export_prepared_suep, format = "sav", path = file.path(dirname(data_dir), "SPSS-test_data_suep"), metadata = TRUE)
```

**Test Configuration**:
* **R version** 4.3.1 (2023-06-16 ucrt)
* **os**       Windows 10 x64 (build 19045)
* **system**  x86_64, mingw32
* **ui**       RStudio
 * **language** (EN)
 * **collate**  German_Germany.utf8
 * **ctype**    German_Germany.utf8

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new code warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules/packages
