### PR TITLE
Fixed deployment of gh-pages/pkgdown trigger

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -6,10 +6,10 @@
 #    types: [newVersionEvent]
 #  workflow_dispatch:
 on:
-    workflow_dispatch:
     push:
         branches:
-            - fix-pkgdown-workflow
+            - main
+    workflow_dispatch:
 permissions:
   contents: write
 name: pkgdown
@@ -42,9 +42,8 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        #if: false
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           clean: false
-          branch: gh-pages-test
+          branch: gh-pages
           folder: docs

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -41,8 +41,8 @@ jobs:
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀
-        #if: github.event_name != 'pull_request'
-        if: false
+        if: github.event_name != 'pull_request'
+        #if: false
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           clean: false

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -1,10 +1,15 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 # This workflow generates documentation pages by using pkdown package and publishes to the repository GitHub page
+#on:
+#  repository_dispatch:
+#    types: [newVersionEvent]
+#  workflow_dispatch:
 on:
-  repository_dispatch:
-    types: [newVersionEvent]
-  workflow_dispatch:
+    workflow_dispatch:
+    push:
+        branches:
+            - fix-pkgdown-workflow
 permissions:
   contents: write
 name: pkgdown
@@ -36,9 +41,10 @@ jobs:
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
+        #if: github.event_name != 'pull_request'
+        if: false
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           clean: false
-          branch: gh-pages
+          branch: gh-pages-test
           folder: docs


### PR DESCRIPTION
The pkgdown workflow was previously triggered only via repository_dispatch, but no workflow or external process was emitting the required newVersionEvent.

As a result, pushes to main never rebuilt or redeployed the pkgdown site, causing GitHub Pages to become outdated.

This PR changes the workflow trigger to automatic deployment on pushes to main.